### PR TITLE
Speed up download of RDS logs

### DIFF
--- a/download-rds-logs.py
+++ b/download-rds-logs.py
@@ -97,11 +97,13 @@ def _main():
                 if 'LogFileData' in result and result['LogFileData'] is not None:
                     if result['LogFileData'].endswith("[Your log message was truncated]\n"):
                         logging.info("Log segment was truncated")
-                        if lines > options.lines * 0.025:
+                        if lines > options.lines * 0.001:
                             if lines > options.lines * 0.1:
                                 lines -= int(options.lines * 0.1)
+                            elif lines > options.lines * 0.01:
+                                lines -= int(options.lines * 0.01)
                             else:
-                                lines -= int(options.lines * 0.025)
+                                lines -= int(options.lines * 0.001)
                             logging.info("retrying with %i lines" % lines)
                             chunks_without_reducing_size = 0
                             continue

--- a/download-rds-logs.py
+++ b/download-rds-logs.py
@@ -118,7 +118,7 @@ def _main():
                 del result['LogFileData']
                 logging.debug(result)
 
-                if chunks_without_reducing_size > 3 and lines < options.lines:
+                if chunks_without_reducing_size > 5 and lines < options.lines:
                     lines += int(options.lines * 0.05)
                     logging.info(f"Increasing chunk size to {lines} lines")
 


### PR DESCRIPTION
Speed up download of RDS logs by reducing number of lines requested more quickly when a request is truncated, and then increasing it again if more than 5 fetches in a row are not truncated.

I also tried resetting the number of lines fetched at once back to the default after each fetch, but that ended up taking significantly longer.